### PR TITLE
Avoid failing cast by initializing journal to same type returned by ReadBytes()

### DIFF
--- a/LiveSplit-Spelunky2.asl
+++ b/LiveSplit-Spelunky2.asl
@@ -39,7 +39,7 @@ init {
   vars.saveptr = IntPtr.Zero;
   vars.checksum = 0;
   vars.lastsum = 0;
-  vars.journal = new List<byte>();
+  vars.journal = new byte[0];
 
   foreach (var page in game.MemoryPages(true)) {
     var scanner = new SignatureScanner(game, page.BaseAddress, (int) page.RegionSize);


### PR DESCRIPTION
Prevents split{} from constantly failing (issue #4). Tested and it seems to make splitting work even when no "Savedata:" message is printed.